### PR TITLE
Add CdrReader seek() and seekTo() methods

### DIFF
--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -1,10 +1,11 @@
 import { CdrReader } from "./CdrReader";
 
+// Example tf2_msgs/TFMessage
+const tf2_msg__TFMessage =
+  "0001000001000000cce0d158f08cf9060a000000626173655f6c696e6b000000060000007261646172000000ae47e17a14ae0e4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f03f";
+
 describe("CdrReader", () => {
   it("parses an example message", () => {
-    // Example tf2_msgs/TFMessage
-    const tf2_msg__TFMessage =
-      "0001000001000000cce0d158f08cf9060a000000626173655f6c696e6b000000060000007261646172000000ae47e17a14ae0e4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f03f";
     const data = Uint8Array.from(Buffer.from(tf2_msg__TFMessage, "hex"));
     const reader = new CdrReader(data);
 
@@ -26,5 +27,21 @@ describe("CdrReader", () => {
     expect(reader.float64()).toBeCloseTo(0); // float64 y
     expect(reader.float64()).toBeCloseTo(0); // float64 z
     expect(reader.float64()).toBeCloseTo(1); // float64 w
+  });
+
+  it("seeks to absolute and relative positions", () => {
+    const data = Uint8Array.from(Buffer.from(tf2_msg__TFMessage, "hex"));
+    const reader = new CdrReader(data);
+
+    reader.seekTo(4 + 4 + 4 + 4 + 4 + 10 + 4 + 6);
+    expect(reader.float64()).toBeCloseTo(3.835);
+
+    // This works due to aligned reads
+    reader.seekTo(4 + 4 + 4 + 4 + 4 + 10 + 4 + 3);
+    expect(reader.float64()).toBeCloseTo(3.835);
+
+    reader.seek(-8);
+    expect(reader.float64()).toBeCloseTo(3.835);
+    expect(reader.float64()).toBeCloseTo(0);
   });
 });

--- a/src/CdrReader.ts
+++ b/src/CdrReader.ts
@@ -109,6 +109,31 @@ export class CdrReader {
     return this.uint32();
   }
 
+  /**
+   * Seek the current read pointer a number of bytes relative to the current position. Note that
+   * seeking before the four-byte header is invalid
+   * @param relativeOffset A positive or negative number of bytes to seek
+   */
+  seek(relativeOffset: number): void {
+    const newOffset = this.offset + relativeOffset;
+    if (newOffset < 4 || newOffset >= this.data.byteLength) {
+      throw new Error(`seek(${relativeOffset}) failed, ${newOffset} is outside the data range`);
+    }
+    this.offset = newOffset;
+  }
+
+  /**
+   * Seek to an absolute byte position in the data. Note that seeking before the four-byte header is
+   * invalid
+   * @param offset An absolute byte offset in the range of [4-byteLength)
+   */
+  seekTo(offset: number): void {
+    if (offset < 4 || offset >= this.data.byteLength) {
+      throw new Error(`seekTo(${offset}) failed, value is outside the data range`);
+    }
+    this.offset = offset;
+  }
+
   private align(size: number): void {
     const alignment = (this.offset - 4) % size;
     if (alignment > 0) {


### PR DESCRIPTION
These methods allow arbitrary seeking of the CDR serialized data during reads which can be useful for lazy deserialization or other custom deserialization approaches
