### PR TITLE
Add EncapsulationKind enum, big-endian uint reader/writers

### DIFF
--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -41,6 +41,14 @@ describe("CdrReader", () => {
     expect(reader.float64()).toBeCloseTo(1); // float64 w
   });
 
+  it("reads big endian values", () => {
+    const data = Uint8Array.from(Buffer.from("000100001234000056789abcdef0000000000000", "hex"));
+    const reader = new CdrReader(data);
+    expect(reader.uint16BE()).toEqual(0x1234);
+    expect(reader.uint32BE()).toEqual(0x56789abc);
+    expect(reader.uint64BE()).toEqual(0xdef0000000000000n);
+  });
+
   it("seeks to absolute and relative positions", () => {
     const data = Uint8Array.from(Buffer.from(tf2_msg__TFMessage, "hex"));
     const reader = new CdrReader(data);

--- a/src/CdrReader.ts
+++ b/src/CdrReader.ts
@@ -1,3 +1,4 @@
+import { EncapsulationKind } from "./encapsulationKind";
 import { isBigEndian } from "./isBigEndian";
 
 interface Indexable {
@@ -30,6 +31,10 @@ export class CdrReader {
   private hostLittleEndian: boolean;
   private textDecoder = new TextDecoder("utf8");
 
+  get kind(): EncapsulationKind {
+    return this.array[1] as EncapsulationKind;
+  }
+
   get data(): Uint8Array {
     return this.array;
   }
@@ -48,7 +53,8 @@ export class CdrReader {
     }
     this.array = data;
     this.view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-    this.littleEndian = data[1] !== 0;
+    const kind = this.kind;
+    this.littleEndian = kind === EncapsulationKind.CDR_LE || kind === EncapsulationKind.PL_CDR_LE;
     this.offset = 4;
   }
 
@@ -102,6 +108,27 @@ export class CdrReader {
   uint64(): bigint {
     this.align(8);
     const value = this.view.getBigUint64(this.offset, this.littleEndian);
+    this.offset += 8;
+    return value;
+  }
+
+  uint16BE(): number {
+    this.align(2);
+    const value = this.view.getUint16(this.offset, false);
+    this.offset += 2;
+    return value;
+  }
+
+  uint32BE(): number {
+    this.align(4);
+    const value = this.view.getUint32(this.offset, false);
+    this.offset += 4;
+    return value;
+  }
+
+  uint64BE(): bigint {
+    this.align(8);
+    const value = this.view.getBigUint64(this.offset, false);
     this.offset += 8;
     return value;
   }

--- a/src/CdrWriter.test.ts
+++ b/src/CdrWriter.test.ts
@@ -60,12 +60,15 @@ describe("CdrWriter", () => {
     writer.uint32(600_000);
     writer.int64(-7_000_000_001n);
     writer.uint64(8_000_000_003n);
+    writer.uint16BE(0x1234);
+    writer.uint32BE(0x12345678);
+    writer.uint64BE(0x123456789abcdef0n);
     writer.float32(-9.14);
     writer.float64(1.7976931348623158e100);
     writer.string("abc");
     writer.sequenceLength(42);
     const data = writer.data;
-    expect(data.byteLength).toEqual(64);
+    expect(data.byteLength).toEqual(80);
 
     const reader = new CdrReader(data);
     expect(reader.int8()).toEqual(-1);
@@ -76,6 +79,9 @@ describe("CdrWriter", () => {
     expect(reader.uint32()).toEqual(600_000);
     expect(reader.int64()).toEqual(-7_000_000_001n);
     expect(reader.uint64()).toEqual(8_000_000_003n);
+    expect(reader.uint16BE()).toEqual(0x1234);
+    expect(reader.uint32BE()).toEqual(0x12345678);
+    expect(reader.uint64BE()).toEqual(0x123456789abcdef0n);
     expect(reader.float32()).toBeCloseTo(-9.14);
     expect(reader.float64()).toBeCloseTo(1.7976931348623158e100);
     expect(reader.string()).toEqual("abc");

--- a/src/encapsulationKind.ts
+++ b/src/encapsulationKind.ts
@@ -1,0 +1,6 @@
+export enum EncapsulationKind {
+  CDR_BE = 0,
+  CDR_LE = 1,
+  PL_CDR_BE = 2,
+  PL_CDR_LE = 3,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./CdrReader";
 export * from "./CdrSizeCalculator";
 export * from "./CdrWriter";
+export * from "./encapsulationKind";


### PR DESCRIPTION
The second byte of the CDR header is an EncapsulationKind enum, not a simple littleEndian boolean. This PR adds support for reading CdrReader#kind and changes the constructor options for CdrWriter to take an optional kind arg instead of bigEndian.

The other change is four new methods on CdrReader and CdrWriter each for reading and writing unsigned integers as big-endian regardless of the endianness of the reader/writer. This is useful for bitflags, enum values, and guids.
