### PR TITLE
Use named option parameters to avoid boolean trap

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -14,5 +14,3 @@ overrides:
       - plugin:@foxglove/typescript
     parserOptions:
       project: ./tsconfig.json
-    rules:
-      "@foxglove/no-boolean-parameters": off

--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -151,8 +151,8 @@ describe("CdrReader", () => {
 
   it("reads multiple arrays", () => {
     const writer = new CdrWriter();
-    writer.float32Array([5.5, 6.5], true);
-    writer.float32Array([7.5, 8.5], true);
+    writer.float32Array([5.5, 6.5], { writeLength: true });
+    writer.float32Array([7.5, 8.5], { writeLength: true });
 
     const reader = new CdrReader(writer.data);
     expect(reader).toBeDefined();
@@ -186,7 +186,7 @@ describe("CdrReader", () => {
     "float64Array",
   ] as const)("handles alignment correctly for empty %s", (key) => {
     const writer = new CdrWriter();
-    writer[key]([], true);
+    writer[key]([], { writeLength: true });
     expect(writer.data.length).toBe(8);
 
     const reader = new CdrReader(writer.data);

--- a/src/CdrWriter.test.ts
+++ b/src/CdrWriter.test.ts
@@ -95,14 +95,14 @@ describe("CdrWriter", () => {
 
   it("round trips all array types", () => {
     const writer = new CdrWriter();
-    writer.int8Array([-128, 127, 3], true);
-    writer.uint8Array([0, 255, 3], true);
-    writer.int16Array([-32768, 32767, -3], true);
-    writer.uint16Array([0, 65535, 3], true);
-    writer.int32Array([-2147483648, 2147483647, 3], true);
-    writer.uint32Array([0, 4294967295, 3], true);
-    writer.int64Array([-9223372036854775808n, 9223372036854775807n, 3n], true);
-    writer.uint64Array([0n, 18446744073709551615n, 3n], true);
+    writer.int8Array([-128, 127, 3], { writeLength: true });
+    writer.uint8Array([0, 255, 3], { writeLength: true });
+    writer.int16Array([-32768, 32767, -3], { writeLength: true });
+    writer.uint16Array([0, 65535, 3], { writeLength: true });
+    writer.int32Array([-2147483648, 2147483647, 3], { writeLength: true });
+    writer.uint32Array([0, 4294967295, 3], { writeLength: true });
+    writer.int64Array([-9223372036854775808n, 9223372036854775807n, 3n], { writeLength: true });
+    writer.uint64Array([0n, 18446744073709551615n, 3n], { writeLength: true });
 
     const reader = new CdrReader(writer.data);
     expect(Array.from(reader.int8Array().values())).toEqual([-128, 127, 3]);

--- a/src/CdrWriter.ts
+++ b/src/CdrWriter.ts
@@ -160,7 +160,7 @@ export class CdrWriter {
 
   int8Array(
     value: Int8Array | number[],
-    { writeLength = false }: { writeLength?: boolean },
+    { writeLength = false }: { writeLength?: boolean } = {},
   ): CdrWriter {
     if (writeLength) {
       this.sequenceLength(value.length);
@@ -173,7 +173,7 @@ export class CdrWriter {
 
   uint8Array(
     value: Uint8Array | number[],
-    { writeLength = false }: { writeLength?: boolean },
+    { writeLength = false }: { writeLength?: boolean } = {},
   ): CdrWriter {
     if (writeLength) {
       this.sequenceLength(value.length);
@@ -186,7 +186,7 @@ export class CdrWriter {
 
   int16Array(
     value: Int16Array | number[],
-    { writeLength = false }: { writeLength?: boolean },
+    { writeLength = false }: { writeLength?: boolean } = {},
   ): CdrWriter {
     if (writeLength) {
       this.sequenceLength(value.length);
@@ -209,7 +209,7 @@ export class CdrWriter {
 
   uint16Array(
     value: Uint16Array | number[],
-    { writeLength = false }: { writeLength?: boolean },
+    { writeLength = false }: { writeLength?: boolean } = {},
   ): CdrWriter {
     if (writeLength) {
       this.sequenceLength(value.length);
@@ -232,7 +232,7 @@ export class CdrWriter {
 
   int32Array(
     value: Int32Array | number[],
-    { writeLength = false }: { writeLength?: boolean },
+    { writeLength = false }: { writeLength?: boolean } = {},
   ): CdrWriter {
     if (writeLength) {
       this.sequenceLength(value.length);
@@ -255,7 +255,7 @@ export class CdrWriter {
 
   uint32Array(
     value: Uint32Array | number[],
-    { writeLength = false }: { writeLength?: boolean },
+    { writeLength = false }: { writeLength?: boolean } = {},
   ): CdrWriter {
     if (writeLength) {
       this.sequenceLength(value.length);
@@ -278,7 +278,7 @@ export class CdrWriter {
 
   int64Array(
     value: BigInt64Array | bigint[] | number[],
-    { writeLength = false }: { writeLength?: boolean },
+    { writeLength = false }: { writeLength?: boolean } = {},
   ): CdrWriter {
     if (writeLength) {
       this.sequenceLength(value.length);
@@ -301,7 +301,7 @@ export class CdrWriter {
 
   uint64Array(
     value: BigUint64Array | bigint[] | number[],
-    { writeLength = false }: { writeLength?: boolean },
+    { writeLength = false }: { writeLength?: boolean } = {},
   ): CdrWriter {
     if (writeLength) {
       this.sequenceLength(value.length);
@@ -324,7 +324,7 @@ export class CdrWriter {
 
   float32Array(
     value: Float32Array | number[],
-    { writeLength = false }: { writeLength?: boolean },
+    { writeLength = false }: { writeLength?: boolean } = {},
   ): CdrWriter {
     if (writeLength) {
       this.sequenceLength(value.length);
@@ -347,7 +347,7 @@ export class CdrWriter {
 
   float64Array(
     value: Float64Array | number[],
-    { writeLength = false }: { writeLength?: boolean },
+    { writeLength = false }: { writeLength?: boolean } = {},
   ): CdrWriter {
     if (writeLength) {
       this.sequenceLength(value.length);

--- a/src/CdrWriter.ts
+++ b/src/CdrWriter.ts
@@ -158,8 +158,11 @@ export class CdrWriter {
     return this.uint32(value);
   }
 
-  int8Array(value: Int8Array | number[], writeLength?: boolean): CdrWriter {
-    if (writeLength === true) {
+  int8Array(
+    value: Int8Array | number[],
+    { writeLength = false }: { writeLength?: boolean },
+  ): CdrWriter {
+    if (writeLength) {
       this.sequenceLength(value.length);
     }
     this.resizeIfNeeded(value.length);
@@ -168,8 +171,11 @@ export class CdrWriter {
     return this;
   }
 
-  uint8Array(value: Uint8Array | number[], writeLength?: boolean): CdrWriter {
-    if (writeLength === true) {
+  uint8Array(
+    value: Uint8Array | number[],
+    { writeLength = false }: { writeLength?: boolean },
+  ): CdrWriter {
+    if (writeLength) {
       this.sequenceLength(value.length);
     }
     this.resizeIfNeeded(value.length);
@@ -178,8 +184,11 @@ export class CdrWriter {
     return this;
   }
 
-  int16Array(value: Int16Array | number[], writeLength?: boolean): CdrWriter {
-    if (writeLength === true) {
+  int16Array(
+    value: Int16Array | number[],
+    { writeLength = false }: { writeLength?: boolean },
+  ): CdrWriter {
+    if (writeLength) {
       this.sequenceLength(value.length);
     }
     if (
@@ -198,8 +207,11 @@ export class CdrWriter {
     return this;
   }
 
-  uint16Array(value: Uint16Array | number[], writeLength?: boolean): CdrWriter {
-    if (writeLength === true) {
+  uint16Array(
+    value: Uint16Array | number[],
+    { writeLength = false }: { writeLength?: boolean },
+  ): CdrWriter {
+    if (writeLength) {
       this.sequenceLength(value.length);
     }
     if (
@@ -218,8 +230,11 @@ export class CdrWriter {
     return this;
   }
 
-  int32Array(value: Int32Array | number[], writeLength?: boolean): CdrWriter {
-    if (writeLength === true) {
+  int32Array(
+    value: Int32Array | number[],
+    { writeLength = false }: { writeLength?: boolean },
+  ): CdrWriter {
+    if (writeLength) {
       this.sequenceLength(value.length);
     }
     if (
@@ -238,8 +253,11 @@ export class CdrWriter {
     return this;
   }
 
-  uint32Array(value: Uint32Array | number[], writeLength?: boolean): CdrWriter {
-    if (writeLength === true) {
+  uint32Array(
+    value: Uint32Array | number[],
+    { writeLength = false }: { writeLength?: boolean },
+  ): CdrWriter {
+    if (writeLength) {
       this.sequenceLength(value.length);
     }
     if (
@@ -258,8 +276,11 @@ export class CdrWriter {
     return this;
   }
 
-  int64Array(value: BigInt64Array | bigint[] | number[], writeLength?: boolean): CdrWriter {
-    if (writeLength === true) {
+  int64Array(
+    value: BigInt64Array | bigint[] | number[],
+    { writeLength = false }: { writeLength?: boolean },
+  ): CdrWriter {
+    if (writeLength) {
       this.sequenceLength(value.length);
     }
     if (
@@ -278,8 +299,11 @@ export class CdrWriter {
     return this;
   }
 
-  uint64Array(value: BigUint64Array | bigint[] | number[], writeLength?: boolean): CdrWriter {
-    if (writeLength === true) {
+  uint64Array(
+    value: BigUint64Array | bigint[] | number[],
+    { writeLength = false }: { writeLength?: boolean },
+  ): CdrWriter {
+    if (writeLength) {
       this.sequenceLength(value.length);
     }
     if (
@@ -298,8 +322,11 @@ export class CdrWriter {
     return this;
   }
 
-  float32Array(value: Float32Array | number[], writeLength?: boolean): CdrWriter {
-    if (writeLength === true) {
+  float32Array(
+    value: Float32Array | number[],
+    { writeLength = false }: { writeLength?: boolean },
+  ): CdrWriter {
+    if (writeLength) {
       this.sequenceLength(value.length);
     }
     if (
@@ -318,8 +345,11 @@ export class CdrWriter {
     return this;
   }
 
-  float64Array(value: Float64Array | number[], writeLength?: boolean): CdrWriter {
-    if (writeLength === true) {
+  float64Array(
+    value: Float64Array | number[],
+    { writeLength = false }: { writeLength?: boolean },
+  ): CdrWriter {
+    if (writeLength) {
       this.sequenceLength(value.length);
     }
     if (


### PR DESCRIPTION
**Public-Facing Changes**
CdrWriter typed array functions now use an options object rather than a plain boolean parameter to avoid the [boolean trap](https://ariya.io/2011/08/hall-of-api-shame-boolean-trap).

**Description**
Fix remaining lint issues from #8.
