### PR TITLE
Add CdrReader#byteLength getter

### DIFF
--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -1,3 +1,4 @@
+import { EncapsulationKind } from ".";
 import { CdrReader } from "./CdrReader";
 import { CdrWriter } from "./CdrWriter";
 
@@ -20,6 +21,7 @@ describe("CdrReader", () => {
   it("parses an example tf2_msgs/TFMessage message", () => {
     const data = Uint8Array.from(Buffer.from(tf2_msg__TFMessage, "hex"));
     const reader = new CdrReader(data);
+    expect(reader.decodedBytes).toBe(4);
 
     // geometry_msgs/TransformStamped[] transforms
     expect(reader.sequenceLength()).toEqual(1);
@@ -41,6 +43,9 @@ describe("CdrReader", () => {
     expect(reader.float64()).toBeCloseTo(1); // float64 w
 
     expect(reader.offset).toBe(data.length);
+    expect(reader.kind).toBe(EncapsulationKind.CDR_LE);
+    expect(reader.decodedBytes).toBe(data.length);
+    expect(reader.byteLength).toBe(data.length);
   });
 
   it("parses an example rcl_interfaces/ParameterEvent", () => {

--- a/src/CdrReader.ts
+++ b/src/CdrReader.ts
@@ -39,6 +39,10 @@ export class CdrReader {
     return this.offset;
   }
 
+  get byteLength(): number {
+    return this.view.byteLength;
+  }
+
   constructor(data: ArrayBufferView) {
     this.hostLittleEndian = !isBigEndian();
 


### PR DESCRIPTION
@foxglove/rtps previously accessed `reader.data.byteLength`, so this getter will act as a replacement.