### PR TITLE
Add support for EMHEADERs and DHEADERs and expand encapsulation kinds to include RTPS

### DIFF
--- a/src/CdrWriter.test.ts
+++ b/src/CdrWriter.test.ts
@@ -41,6 +41,12 @@ const CDR2EncapsulationKinds = new Set<EncapsulationKind>([
   EncapsulationKind.PL_CDR2_LE,
   EncapsulationKind.DELIMITED_CDR2_BE,
   EncapsulationKind.DELIMITED_CDR2_LE,
+  EncapsulationKind.RTPS_CDR2_BE,
+  EncapsulationKind.RTPS_CDR2_LE,
+  EncapsulationKind.RTPS_PL_CDR2_BE,
+  EncapsulationKind.RTPS_PL_CDR2_LE,
+  EncapsulationKind.RTPS_DELIMITED_CDR2_BE,
+  EncapsulationKind.RTPS_DELIMITED_CDR2_LE,
 ]);
 const AllCdrWriterKinds: (keyof typeof EncapsulationKind)[] = enumKeys(EncapsulationKind);
 
@@ -171,7 +177,7 @@ describe("CdrWriter", () => {
   });
 
   it("aligns cdr2", () => {
-    const writer = new CdrWriter({ kind: EncapsulationKind.CDR2_LE });
+    const writer = new CdrWriter({ kind: EncapsulationKind.RTPS_PL_CDR2_LE });
     writer.align(0);
     expect(toHex(writer.data)).toEqual("000b0000");
     writer.align(4);

--- a/src/EncapsulationKind.ts
+++ b/src/EncapsulationKind.ts
@@ -1,6 +1,6 @@
 // From <https://www.omg.org/spec/DDS-XTypes/1.2/PDF>
 // "7.4.3.4 Functions related to data types and objects"
-//
+// ENC_HEADER
 // {0x00, 0x00} -- PLAIN_CDR, BIG_ENDIAN,
 // {0x00, 0x01} -- PLAIN_CDR, LITTLE_ENDIAN
 // {0x00, 0x02} -- PL_CDR, BIG_ENDIAN,
@@ -12,27 +12,59 @@
 // {0x00, 0x14} -- DELIMIT_CDR, BIG_ENDIAN
 // {0x00, 0x15} -- DELIMIT_CDR, LITTLE_ENDIAN
 //
-// Verified with RTI Connext that 0x11 refers to decimal 11 (0x0B).
+// 7.6.2.1.2 RTPS encapsulation identifier
+// XCDR VERSION 1
+// {0x00, 0x00} -- CDR_BE, BIG_ENDIAN, FINAL
+// {0x00, 0x01} -- CDR_LE, LITTLE_ENDIAN, FINAL
+// {0x00, 0x00} -- CDR_BE, BIG_ENDIAN, APPENDABLE
+// {0x00, 0x01} -- CDR_LE, LITTLE_ENDIAN, APPENDABLE
+// {0x00, 0x02} -- PL_CDR_BE, BIG_ENDIAN, MUTABLE
+// {0x00, 0x03} -- PL_CDR_LE, LITTLE_ENDIAN, MUTABLE
+//
+// XCDR VERSION 2
+// {0x00, 0x06} -- CDR2_BE, BIG_ENDIAN, FINAL
+// {0x00, 0x07} -- CDR2_LE, LITTLE_ENDIAN, FINAL
+// {0x00, 0x08} -- D_CDR2_BE, BIG_ENDIAN, APPENDABLE
+// {0x00, 0x09} -- D_CDR2_LE, LITTLE_ENDIAN, APPENDABLE
+// {0x00, 0x0a} -- PL_CDR2_BE, BIG_ENDIAN, MUTABLE
+// {0x00, 0x0b} -- PL_CDR2_LE, LITTLE_ENDIAN, MUTABLE
 
 export enum EncapsulationKind {
+  // Both RTPS and ENC_HEADER enum values
   /** Plain CDR, big-endian */
-  CDR_BE = 0,
+  CDR_BE = 0x00,
   /** Plain CDR, little-endian */
-  CDR_LE = 1,
+  CDR_LE = 0x01,
   /** Parameter List CDR, big-endian */
-  PL_CDR_BE = 2,
+  PL_CDR_BE = 0x02,
   /** Parameter List CDR, little-endian */
-  PL_CDR_LE = 3,
+  PL_CDR_LE = 0x03,
+
+  // ENC_HEADER enum values
   /** Plain CDR2, big-endian */
-  CDR2_BE = 10,
+  CDR2_BE = 0x10,
   /** Plain CDR2, little-endian */
-  CDR2_LE = 11,
+  CDR2_LE = 0x11,
   /** Parameter List CDR2, big-endian */
-  PL_CDR2_BE = 12,
+  PL_CDR2_BE = 0x12,
   /** Parameter List CDR2, little-endian */
-  PL_CDR2_LE = 13,
+  PL_CDR2_LE = 0x13,
   /** Delimited CDR, big-endian */
-  DELIMITED_CDR2_BE = 14,
+  DELIMITED_CDR2_BE = 0x14,
   /** Delimited CDR, little-endian */
-  DELIMITED_CDR2_LE = 15,
+  DELIMITED_CDR2_LE = 0x15,
+
+  // RTPS enum values
+  /** Plain CDR2, big-endian */
+  RTPS_CDR2_BE = 0x06,
+  /** Plain CDR2, little-endian */
+  RTPS_CDR2_LE = 0x07,
+  /** Delimited CDR, big-endian */
+  RTPS_DELIMITED_CDR2_BE = 0x08,
+  /** Delimited CDR, little-endian */
+  RTPS_DELIMITED_CDR2_LE = 0x09,
+  /** Parameter List CDR2, big-endian */
+  RTPS_PL_CDR2_BE = 0x0a,
+  /** Parameter List CDR2, little-endian */
+  RTPS_PL_CDR2_LE = 0x0b,
 }

--- a/src/getEncapsulationKindInfo.ts
+++ b/src/getEncapsulationKindInfo.ts
@@ -1,0 +1,71 @@
+import { EncapsulationKind } from "./EncapsulationKind";
+
+// From <https://www.omg.org/spec/DDS-XTypes/1.2/PDF>
+// 7.4.2 Extended CDR Representation
+/**
+ * Excerpt:
+ * PLAIN_CDR2 shall be used for all primitive, strings, and enumerated types. It is also
+ * used for any type with extensibility kind FINAL. The encoding is similar to
+ * PLAIN_CDR except that INT64, UINT64, FLOAT64, and FLOAT128 are serialized into
+ * the CDR buffer at offsets that are aligned to 4 rather than 8 as was the case in
+ * PLAIN_CDR.
+ *
+ * DELIMITED_CDR shall be used for types with extensibility kind APPENDABLE. It
+ * serializes a UINT32 delimiter header (DHEADER) before serializing the object using
+ * PLAIN_CDR2. The delimiter encodes the endianness and the length of the serialized
+ * object that follows.
+ *
+ * PL_CDR2 shall be used for aggregated types with extensibility kind MUTABLE.
+ * Similar to DELIMITED_CDR it also serializes a DHEADER before serializing the
+ * object. In addition it serializes a member header (EMHEADER) ahead each serialized
+ * member. The member header encodes the member ID, the must-understand flag, and
+ * length of the serialized member that follows.
+ */
+
+/**
+ * Extracts information about the serialization behavior of an EncapsulationKind. Such as whether it's CDR2, little-endian, uses a delimiter header or uses a member header.
+ * @param kind - EncapsulationKind to extract information from
+ * @returns {Object} - Object containing boolean values that describe the serialization behavior of the EncapsulationKind
+ */
+export const getEncapsulationKindInfo = (
+  kind: EncapsulationKind,
+): {
+  isCDR2: boolean;
+  littleEndian: boolean;
+  usesDelimiterHeader: boolean;
+  usesMemberHeader: boolean;
+} => {
+  const isCDR2 = kind > EncapsulationKind.PL_CDR_LE;
+
+  const littleEndian =
+    kind === EncapsulationKind.CDR_LE ||
+    kind === EncapsulationKind.PL_CDR_LE ||
+    kind === EncapsulationKind.CDR2_LE ||
+    kind === EncapsulationKind.PL_CDR2_LE ||
+    kind === EncapsulationKind.DELIMITED_CDR2_LE ||
+    kind === EncapsulationKind.RTPS_CDR2_LE ||
+    kind === EncapsulationKind.RTPS_PL_CDR2_LE ||
+    kind === EncapsulationKind.RTPS_DELIMITED_CDR2_LE;
+
+  const isDelimitedCDR2 =
+    kind === EncapsulationKind.DELIMITED_CDR2_BE ||
+    kind === EncapsulationKind.DELIMITED_CDR2_LE ||
+    kind === EncapsulationKind.RTPS_DELIMITED_CDR2_BE ||
+    kind === EncapsulationKind.RTPS_DELIMITED_CDR2_LE;
+
+  const isPLCDR2 =
+    kind === EncapsulationKind.PL_CDR2_BE ||
+    kind === EncapsulationKind.PL_CDR2_LE ||
+    kind === EncapsulationKind.RTPS_PL_CDR2_BE ||
+    kind === EncapsulationKind.RTPS_PL_CDR2_LE;
+
+  const usesDelimiterHeader = isDelimitedCDR2 || isPLCDR2;
+  const usesMemberHeader = isPLCDR2;
+
+  return {
+    isCDR2,
+    littleEndian,
+    usesDelimiterHeader,
+    usesMemberHeader,
+  };
+};


### PR DESCRIPTION
- fix old Encapsulation kind enums to not use decimals (this was incorrect)
- add support for RTPS encapsulation kinds
- add functions for reading and writing DHEADERs and EMHEADERs for PL and DELIMITED encapsulation types
- Reader now reveals underlying encapsulation type information for higher level serialization logic such as writing DHEADERs and EMHEADERs