### PR TITLE
Update CDR reader to be compliant with DDS-XTypes v1.3 spec instead of v1.2 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Common Data Representation (CDR) defines a serialization format for primitive types. When combined with an Interface Definition Language (IDL) it can be used to create complex types that can be serialized to disk, transmitted over the network, etc. while transparently handling endianness and alignment requirements. It's specified by https://www.omg.org/spec/DDSI-RTPS/2.3/PDF (chapter 10) and https://www.omg.org/cgi-bin/doc?formal/02-06-51.
 
+XCDR implementation follows [DDS-XTypes V1.3 specification](https://www.omg.org/spec/DDS-XTypes/1.3/PDF).
+
 CDR is found in OMG DDS (Data Distributed Service) implementations such as the Real-Time Publish Subscribe (RTPS) protocol. This is the wire protocol found in ROS2, and CDR is the default serialization format used in rosbag2.
 
 ## Usage

--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -198,6 +198,16 @@ describe("CdrReader", () => {
     expect(reader[key]().length).toEqual(0);
     expect(reader.offset).toEqual(writer.data.length);
   });
+
+  it("takes a length when reading a string and doesn't read the sequence length again", () => {
+    const writer = new CdrWriter();
+    const testString = "test";
+    writer.string(testString);
+
+    const reader = new CdrReader(writer.data);
+    const length = reader.sequenceLength();
+    expect(reader.string(length)).toEqual("test");
+  });
   it.each([[1], [2], [4], [8], [0x7fffffff]])(
     "round trips DHEADER values of size %d",
     (objectSize) => {

--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -206,10 +206,7 @@ describe("CdrReader", () => {
       writer.dHeader(objectSize);
 
       const reader = new CdrReader(writer.data);
-      expect(reader.dHeader()).toEqual({
-        objectSize,
-        littleEndianFlag: true,
-      });
+      expect(reader.dHeader()).toEqual(objectSize);
     },
   );
 

--- a/src/CdrWriter.ts
+++ b/src/CdrWriter.ts
@@ -153,9 +153,12 @@ export class CdrWriter {
     return this;
   }
 
-  string(value: string): CdrWriter {
+  // writeLength optional because it could already be included in a header
+  string(value: string, writeLength = true): CdrWriter {
     const strlen = value.length;
-    this.uint32(strlen + 1); // Add one for the null terminator
+    if (writeLength) {
+      this.uint32(strlen + 1); // Add one for the null terminator
+    }
     this.resizeIfNeeded(strlen + 1);
     this.textEncoder.encodeInto(value, new Uint8Array(this.buffer, this.offset, strlen));
     this.view.setUint8(this.offset + strlen, 0);

--- a/src/CdrWriter.ts
+++ b/src/CdrWriter.ts
@@ -163,26 +163,12 @@ export class CdrWriter {
     return this;
   }
 
-  /** Writes the delimiter header returning the endianness flag and object size
+  /** Writes the delimiter header using object size
    * NOTE: changing endian-ness with a single CDR message is not supported
    */
   dHeader(objectSize: number): CdrWriter {
-    // We don't support changing the endianness mid-stream, mostly because we don't have data to test it with
-    const littleEndianFlag = this.littleEndian;
-    // DHEADER(O) = (E_FLAG<< 31) + O.ssize
-    if (objectSize < 1) {
-      throw new Error("Object size must be positive integer for DHEADER");
-    }
-    /**
-     * E = 1 indicates that following the header XCDR stream
-     * endianness shall be changed to LITTLE_ENDIAN.
-     * E = 0 indicates that following the header XCDR stream
-     * endianness shall be changed to BIG_ENDIAN.
-     */
-
-    const flag = littleEndianFlag ? 1 << 31 : 0;
-
-    const header = flag | objectSize;
+    // DHEADER(O) = O.ssize
+    const header = objectSize;
     this.uint32(header);
 
     return this;

--- a/src/EncapsulationKind.ts
+++ b/src/EncapsulationKind.ts
@@ -1,4 +1,5 @@
-// From <https://www.omg.org/spec/DDS-XTypes/1.2/PDF>
+// From <https://www.omg.org/spec/DDS-XTypes/1.3/PDF>
+// ============= NOTE DDS-XTypes spec v1.3 ==========
 // "7.4.3.4 Functions related to data types and objects"
 // ENC_HEADER
 // {0x00, 0x00} -- PLAIN_CDR, BIG_ENDIAN,


### PR DESCRIPTION
Changes for 1.3 from 1.2:
 - Length code multipliers changed
 - endian-ness flag no longer written/read

Outside of spec changes I've also updated the `string` reader to accept a pre-read length (like that which is included in EMHEADERs), so that message deserializers can control whether it reads a sequence length.