### PR TITLE
Minor version bump for PL_CDRv1 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/cdr",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Common Data Representation serialization and deserialization library",
   "license": "MIT",
   "keywords": [

--- a/src/CdrWriter.ts
+++ b/src/CdrWriter.ts
@@ -224,6 +224,7 @@ export class CdrWriter {
   /** Writes the PID_SENTINEL value if encapsulation supports it*/
   sentinelHeader(): CdrWriter {
     if (!this.isCDR2) {
+      this.align(4);
       this.uint16(SENTINEL_PID);
       this.uint16(0);
     }


### PR DESCRIPTION
- emHeader now writes/reads both PL_CDRv2 and PL_CDRv1 based off the encapsulation kind