### PR TITLE
Expose read/write lengthcode for CDR2 emheaders

### DIFF
--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -302,7 +302,7 @@ Object {
     [false, 1028, 4, 2], // LC 2, 4 bytes
     [false, 65, 8, 3], // LC 3, 8 bytes
     [true, 63, 9, 4], // LC 4, any size
-    [false, 127, 0xffffffff, 5], // LC
+    [false, 127, 0xffffffff, 5], // LC 5, any size
     [false, 65, 12, 6], // LC 6, multiple of 4 bytes
     [false, 65, 32, 7], // LC 7, multiple of 8 bytes
   ])(

--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -305,7 +305,6 @@ Object {
     [false, 127, 0xffffffff, 5], // LC
     [false, 65, 12, 6], // LC 6, multiple of 4 bytes
     [false, 65, 32, 7], // LC 7, multiple of 8 bytes
-    [false, 127, 0xffffffff, 5],
   ])(
     "round trips EMHEADER values with mustUnderstand: %d, id: %d, size: %d, and lengthCode: %d",
     (mustUnderstand: boolean, id: number, objectSize: number, lengthCode: number) => {

--- a/src/CdrReader.ts
+++ b/src/CdrReader.ts
@@ -1,7 +1,7 @@
 import { EncapsulationKind } from "./EncapsulationKind";
 import { getEncapsulationKindInfo } from "./getEncapsulationKindInfo";
 import { isBigEndian } from "./isBigEndian";
-import { lengthCodeToObjectSizes } from "./lengthCodes";
+import { LengthCode, lengthCodeToObjectSizes } from "./lengthCodes";
 import { EXTENDED_PID, SENTINEL_PID } from "./reservedPIDs";
 
 interface Indexable {
@@ -188,8 +188,9 @@ export class CdrReader {
   /**
    * Reads the member header (EMHEADER) and returns the member ID, mustUnderstand flag, and object size with optional length code
    * The length code is only present in CDR2 and should prompt objectSize to be used in place of sequence length if applicable.
+   * See Extensible and Dynamic Topic Types (DDS-XTypes) v1.3 @ `7.4.3.4.2` for more info about CDR2 EMHEADER composition.
    */
-  emHeader(): { mustUnderstand: boolean; id: number; objectSize: number; lengthCode?: number } {
+  emHeader(): { mustUnderstand: boolean; id: number; objectSize: number; lengthCode?: LengthCode } {
     if (this.isCDR2) {
       return this.memberHeaderV2();
     } else {
@@ -270,7 +271,7 @@ export class CdrReader {
     id: number;
     objectSize: number;
     mustUnderstand: boolean;
-    lengthCode: number;
+    lengthCode: LengthCode;
   } {
     const header = this.uint32();
     // EMHEADER = (M_FLAG<<31) + (LC<<28) + M.id
@@ -278,7 +279,7 @@ export class CdrReader {
     // M_FLAG is the value of the Must Understand option for the member
     const mustUnderstand = Math.abs((header & 0x80000000) >> 31) === 1;
     // LC is the value of the Length Code for the member.
-    const lengthCode = (header & 0x70000000) >> 28;
+    const lengthCode = ((header & 0x70000000) >> 28) as LengthCode;
     const id = header & 0x0fffffff;
 
     const objectSize = this.emHeaderObjectSize(lengthCode);
@@ -289,7 +290,7 @@ export class CdrReader {
   /** Uses the length code to derive the member object size in
    * the EMHEADER, sometimes reading NEXTINT (the next uint32
    * following the header) from the buffer */
-  private emHeaderObjectSize(lengthCode: number) {
+  private emHeaderObjectSize(lengthCode: LengthCode) {
     // 7.4.3.4.2 Member Header (EMHEADER), Length Code (LC) and NEXTINT
     switch (lengthCode) {
       case 0:
@@ -308,6 +309,7 @@ export class CdrReader {
         return 8 * this.uint32();
       default:
         throw new Error(
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           `Invalid length code ${lengthCode} in EMHEADER at offset ${this.offset - 4}`,
         );
     }

--- a/src/lengthCodes.ts
+++ b/src/lengthCodes.ts
@@ -1,5 +1,7 @@
-export function getLengthCodeForObjectSize(objectSize: number): number {
-  let defaultLengthCode;
+export type LengthCode = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export function getLengthCodeForObjectSize(objectSize: number): LengthCode {
+  let defaultLengthCode: LengthCode | undefined;
 
   switch (objectSize) {
     case 1:

--- a/src/lengthCodes.ts
+++ b/src/lengthCodes.ts
@@ -1,0 +1,36 @@
+export function getLengthCodeForObjectSize(objectSize: number): number {
+  let defaultLengthCode;
+
+  switch (objectSize) {
+    case 1:
+      defaultLengthCode = 0;
+      break;
+    case 2:
+      defaultLengthCode = 1;
+      break;
+    case 4:
+      defaultLengthCode = 2;
+      break;
+    case 8:
+      defaultLengthCode = 3;
+      break;
+  }
+
+  if (defaultLengthCode == undefined) {
+    // Not currently supporting writing of lengthCodes > 4
+    if (objectSize > 0xffffffff) {
+      throw Error(
+        `Object size ${objectSize} for EMHEADER too large without specifying length code. Max size is ${0xffffffff}`,
+      );
+    }
+    defaultLengthCode = 4;
+  }
+  return defaultLengthCode;
+}
+
+export const lengthCodeToObjectSizes = {
+  0: 1,
+  1: 2,
+  2: 4,
+  3: 8,
+};


### PR DESCRIPTION
This was already being read and written, but not exposed for reading or writing. The reason for exposing this now is because for lengthCodes 5-7 it means that it should also be used in place of length where certain members start with an integer length, like for sequenceLength or dHeaders of structs.

<img width="721" alt="image" src="https://github.com/foxglove/cdr/assets/10187776/46e8f74e-7d0b-4ab2-a63f-58161c3d29e3">
