### PR TITLE
minor version bump to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/cdr",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Common Data Representation serialization and deserialization library",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
emHeader returns optional value representing whether it read a sentinelHeader for PL_CDR v1 encodings.

Previously it errored when reading a sentinel header. 