### PR TITLE
Various fixes and improvements for CdrReader (isPresent flag, consume whole sentinelHeader in emHeader, allow to seek to offset at end of buffer, isCdr2 exposure)

### DIFF
--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -419,6 +419,16 @@ describe("limit()", () => {
     const reader = new CdrReader(writer.data);
     expect(() => reader.isPresentFlag()).toThrow(Error);
   });
+  it("can seek to end of the buffer", () => {
+    const writer = new CdrWriter({ size: 8 });
+    writer.int32(1);
+    const reader = new CdrReader(writer.data);
+    // important because sometimes we seek to the end of objects in the buffer
+    // and it might be the end of the buffer.
+    reader.seekTo(8);
+    expect(reader.isAtEnd()).toBe(true);
+    expect(() => reader.int32()).toThrow(RangeError);
+  });
 });
 
 function writeArray(writer: CdrWriter, setter: Setter, array: number[]): void {

--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -403,7 +403,7 @@ describe("limit()", () => {
     const writer = new CdrWriter({ kind: EncapsulationKind.CDR_LE });
     writer.uint8(1); // placeholder, won't be read
     const reader = new CdrReader(writer.data);
-    expect(() => reader.isPresentFlag()).toThrow(Error);
+    expect(() => reader.isPresentFlag()).toThrowError(/only supported for CDR2/i);
   });
   it("can seek to end of the buffer", () => {
     const writer = new CdrWriter({ size: 8 });

--- a/src/CdrReader.test.ts
+++ b/src/CdrReader.test.ts
@@ -390,20 +390,6 @@ describe("limit()", () => {
     reader.limit(1);
     expect(() => reader.limit(2)).toThrow(RangeError);
   });
-  it("can detect sentinel header using maybeConsumeSentinelHeader", () => {
-    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
-    writer.uint16(25);
-    writer.sentinelHeader();
-    const reader = new CdrReader(writer.data);
-    let offsetBefore = reader.offset;
-    expect(reader.maybeConsumeSentinelHeader()).toBe(false);
-    expect(reader.offset).toBe(offsetBefore);
-    const value = reader.uint16();
-    expect(value).toBe(25);
-    offsetBefore = reader.offset;
-    expect(reader.maybeConsumeSentinelHeader()).toBe(true);
-    expect(reader.offset).not.toBe(offsetBefore);
-  });
 
   it("can read and write present flags when using CDR2", () => {
     const writer = new CdrWriter({ kind: EncapsulationKind.CDR2_LE });

--- a/src/CdrReader.ts
+++ b/src/CdrReader.ts
@@ -423,7 +423,7 @@ export class CdrReader {
    */
   seek(relativeOffset: number): void {
     const newOffset = this.offset + relativeOffset;
-    if (newOffset < 4 || newOffset >= this.view.byteLength) {
+    if (newOffset < 4 || newOffset > this.view.byteLength) {
       throw new Error(`seek(${relativeOffset}) failed, ${newOffset} is outside the data range`);
     }
     this.offset = newOffset;
@@ -435,7 +435,7 @@ export class CdrReader {
    * @param offset An absolute byte offset in the range of [4-byteLength)
    */
   seekTo(offset: number): void {
-    if (offset < 4 || offset >= this.view.byteLength) {
+    if (offset < 4 || offset > this.view.byteLength) {
       throw new Error(`seekTo(${offset}) failed, value is outside the data range`);
     }
     this.offset = offset;

--- a/src/CdrWriter.ts
+++ b/src/CdrWriter.ts
@@ -16,9 +16,10 @@ export class CdrWriter {
   static DEFAULT_CAPACITY = 16;
   static BUFFER_COPY_THRESHOLD = 10;
 
+  public readonly isCDR2: boolean;
+
   private littleEndian: boolean;
   private hostLittleEndian: boolean;
-  private isCDR2: boolean;
   private eightByteAlignment: number; // Alignment for 64-bit values, 4 on CDR2 8 on CDR1
   private buffer: ArrayBuffer;
   private array: Uint8Array;
@@ -241,6 +242,17 @@ export class CdrWriter {
   /** Sets the origin to the offset (DDS-XTypes Spec: `PUSH(ORIGIN = 0)`)*/
   private resetOrigin() {
     this.origin = this.offset;
+  }
+
+  /** Writes boolean flag for optional members in CDR2
+   * @throws Error if called for CDR1.
+   */
+  presentFlag(value: boolean): CdrWriter {
+    if (!this.isCDR2) {
+      throw new Error("presentFlag is only supported for CDR2");
+    }
+    this.uint8(value ? 1 : 0);
+    return this;
   }
 
   /** Writes the PID_SENTINEL value if encapsulation supports it*/


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

 - Added isPresentFlag method for reading boolean values that precede optional final members for XCDR2 encoded messages
 - Update bound checks in seek and seekTo to allow for seeking to `offset==buffer.bytelength` to allow for seeking to the end of objects which take up the remainder of the buffer.
 - When we read the sentinelHeader in the emHeader we read all of the sentinel header rather than just the SENTINEL_PID.
 - reveal whether the reader is reading a CDR2 stream or not.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

