### PR TITLE
v3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/cdr",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Common Data Representation serialization and deserialization library",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

From https://github.com/foxglove/cdr/pull/31
 - Added isPresentFlag method for reading boolean values that precede optional final members for XCDR2 encoded messages
 - Update bound checks in seek and seekTo to allow for seeking to `offset==buffer.bytelength` to allow for seeking to the end of objects which take up the remainder of the buffer.
 - When we read the sentinelHeader in the emHeader we read all of the sentinel header rather than just the SENTINEL_PID.
 - reveal whether the reader is reading a CDR2 stream or not.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

