### PR TITLE
Prepare v3.5.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ console.log(reader.sequenceLength());
 
 ## Releasing
 
-1. Run `yarn version --[major|minor|patch]` to bump version
+1. Run `yarn version [major|minor|patch]` to bump version
 2. Run `git push && git push --tags` to push new tag
 3. GitHub Actions will take care of the rest
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/cdr",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "packageManager": "yarn@4.12.0",
   "description": "Common Data Representation serialization and deserialization library",
   "license": "MIT",


### PR DESCRIPTION
## Description

Prepare the package for the v3.5.1 patch release by bumping @foxglove/cdr from 3.5.0 to 3.5.1.

Update the release instructions to match Yarn 4 syntax for version bumps.

## Validation

- yarn build
- yarn lint:ci (passes with existing jest/expect-expect warning in src/CdrReader.test.ts)
- yarn test